### PR TITLE
fix: call hasYarn instead of using the function reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function yarnOrNpm() {
     } catch (e) {}
   }
 
-  return hasYarn ? 'yarn' : 'npm';
+  return hasYarn() ? 'yarn' : 'npm';
 }
 
 function spawn(...args) {


### PR DESCRIPTION
There was a regression in 3.0.0, where in `yarnOrNpm`, instead of comparing the return value of `hasYarn()` to determine which package manager to use, it compared the truthiness of `hasYarn` (which is always true) and so yarn is always selected, even if it's not installed.